### PR TITLE
Stutter and uwu-stutter routes now are different things.

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -16,6 +16,11 @@ async def translate_to_uwu(string: str) -> dict:
 
 
 @app.get("/stutter/{string}")
+async def translate_to_uwu(string: str) -> dict:
+    """Makes a string stutter."""
+    return {"message": stutter(string)}
+
+
 @app.get("/uwu-stutter/{string}")
 async def translate_to_uwu(string: str) -> dict:
     """Adds uwu *with* a stutter."""


### PR DESCRIPTION
```python3
>>> requests.get('http://localhost:8005/uwu-stutter/hello%20world').json()
{'message': 'h-hewwo w-wowwd'}
>>> requests.get('http://localhost:8005/stutter/hello%20world').json()
{'message': 'h-h-hello w-w-world'}
```